### PR TITLE
#87 Pull-Request hot fixed.

### DIFF
--- a/src/entity/Bullet.java
+++ b/src/entity/Bullet.java
@@ -57,9 +57,10 @@ public class Bullet extends Entity {
 	 */
 	public Bullet(final int positionX, final int positionY, final int speed, SpriteType bulletType) {
 		super(positionX, positionY, 3 * 2, 5 * 2, Color.WHITE);
-
+		this.bulletEffect = new BulletEffect(this);
 		this.speed = speed;
 		this.spriteType = bulletType;
+		this.effectBullet = 0;
 	}
 
 	/**


### PR DESCRIPTION
펩시제로 팀 제보로 버그 픽스하였습니다.
원인은 적 불릿 생성자용으로 쓰이던 Bullet()에서 BulletEffect를 사용하지 않는다고 판단하여 넣지 않았으나,
BulletPool에서 불릿 재사용으로 적의 불릿을 Ship의 불릿으로 불러오면서 BulletEffect 참조가 null이 되어 널포인터 에러가 떴었습니다. 제보 감사합니다
---
We fixed the bug with PepsiZero team report.
The reason was that Bullet(), which was used for the enemy bullet generator, did not use BulletEffect, so I don't add BulletEffect.
But, BulletPool brought the enemy's bulllet to the Ship's bullit by using BulletPool's reuse, and BulletEffect reference was null, resulting in a null pointer error. 
So That's fixed.
Thank you for the report